### PR TITLE
Aded definition for Vext on pin 21 in heltec.h

### DIFF
--- a/library.json
+++ b/library.json
@@ -10,7 +10,7 @@
         "name": "Heltec Automation(TM)",
         "email": "support@heltec.cn"
    },
-  "version": "1.0.3",
+  "version": "1.0.4",
   "frameworks": "arduino",
   "platforms": "espressif32"
 }

--- a/src/heltec.h
+++ b/src/heltec.h
@@ -5,6 +5,8 @@
 
 #if defined(ESP32)
 
+#define Vext 21
+
 #include <Arduino.h>
 #include <Wire.h>
 
@@ -36,7 +38,7 @@ class Heltec_ESP32 {
 extern Heltec_ESP32 Heltec;
 
 #else
-#error ¡°This library only supports boards with ESP32 processor.¡±
+#error ï¿½ï¿½This library only supports boards with ESP32 processor.ï¿½ï¿½
 #endif
 
 


### PR DESCRIPTION
This corrects the error Vext not defined. 