### PR TITLE
Disambiguate Wire.begin for arduino-esp32@2.0.1

### DIFF
--- a/src/BMP180.cpp
+++ b/src/BMP180.cpp
@@ -9,7 +9,7 @@ boolean BMP085::begin(uint8_t mode) {
     mode = BMP085_ULTRAHIGHRES;
   oversampling = mode;
 //begin(int sdaPin, int sclPin, uint32_t frequency)
-  Wire.begin(13, 12, 100000);
+  Wire.begin(13, 12, 100000U);
 
   if (read8(0xD0) != 0x55) return false;
 

--- a/src/oled/SSD1306Wire.h
+++ b/src/oled/SSD1306Wire.h
@@ -55,16 +55,16 @@ class SSD1306Wire : public OLEDDisplay {
 
 
     bool connect() {
-    		pinMode(_rst,OUTPUT);
-    		digitalWrite(_rst, LOW);
-    		delay(50);
-    		digitalWrite(_rst, HIGH);
+			pinMode(_rst,OUTPUT);
+			digitalWrite(_rst, LOW);
+			delay(50);
+			digitalWrite(_rst, HIGH);
 
-		Wire.begin(this->_sda, this->_scl);
-		// Let's use ~700khz if ESP8266 is in 160Mhz mode
-		// this will be limited to ~400khz if the ESP8266 in 80Mhz mode.
-		Wire.setClock(700000);
-		return true;
+			// Let's use ~700khz if ESP8266 is in 160Mhz mode
+			// this will be limited to ~400khz if the ESP8266 in 80Mhz mode.
+			Wire.begin(int(this->_sda), this->_scl, 700000U);
+			
+			return true;
     }
 
     void display(void) {


### PR DESCRIPTION
A four-parameter overload of `TwoWire::begin` was added to implement I2C slaves in [arduino-esp32@2.0.1-RC1](https://github.com/espressif/arduino-esp32/releases/tag/2.0.1-RC1) (https://github.com/espressif/arduino-esp32/commit/f9f70d2f73d16f7fb50f59e05323cd041acce830):

[Wire.h](https://github.com/espressif/arduino-esp32/blob/f9f70d2f73d16f7fb50f59e05323cd041acce830/libraries/Wire/src/Wire.h): ```bool begin(uint8_t slaveAddr, int sda=-1, int scl=-1, uint32_t frequency=0)```

GCC 8.4.0 (via [espressif/crosstool-NG esp-2021r1](https://github.com/espressif/crosstool-NG/releases/tag/esp-2021r1)) can't disambiguate the three-argument call when the first and third arguments are signed or `uint16_t`.

The literal `100000U` evaluates to `uint32_t` and resolves the three-parameter overload.

If the first argument evaluates to `unsigned int` then the library tries to slave the MCU with `frequency = 0`.