### PR TITLE
Disambiguate TwoWire::begin for arduino-esp32@2.0.1

### DIFF
--- a/src/BMP180.cpp
+++ b/src/BMP180.cpp
@@ -9,7 +9,7 @@ boolean BMP085::begin(uint8_t mode) {
     mode = BMP085_ULTRAHIGHRES;
   oversampling = mode;
 //begin(int sdaPin, int sclPin, uint32_t frequency)
-  Wire.begin(13, 12, 100000);
+  Wire.begin(13, 12, 100000U);
 
   if (read8(0xD0) != 0x55) return false;
 

--- a/src/oled/SSD1306Wire.h
+++ b/src/oled/SSD1306Wire.h
@@ -55,16 +55,16 @@ class SSD1306Wire : public OLEDDisplay {
 
 
     bool connect() {
-    		pinMode(_rst,OUTPUT);
-    		digitalWrite(_rst, LOW);
-    		delay(50);
-    		digitalWrite(_rst, HIGH);
+			pinMode(_rst,OUTPUT);
+			digitalWrite(_rst, LOW);
+			delay(50);
+			digitalWrite(_rst, HIGH);
 
-		Wire.begin(this->_sda, this->_scl);
-		// Let's use ~700khz if ESP8266 is in 160Mhz mode
-		// this will be limited to ~400khz if the ESP8266 in 80Mhz mode.
-		Wire.setClock(700000);
-		return true;
+			// Let's use ~700khz if ESP8266 is in 160Mhz mode
+			// this will be limited to ~400khz if the ESP8266 in 80Mhz mode.
+			Wire.begin(int(this->_sda), this->_scl, 700000U);
+		
+			return true;
     }
 
     void display(void) {


### PR DESCRIPTION
A four-parameter overload of `TwoWire::begin` was added to implement I2C slaves in [arduino-esp32@2.0.1-RC1](https://github.com/espressif/arduino-esp32/releases/tag/2.0.1-RC1) (https://github.com/espressif/arduino-esp32/commit/f9f70d2f73d16f7fb50f59e05323cd041acce830):

[```bool begin(uint8_t slaveAddr, int sda=-1, int scl=-1, uint32_t frequency=0)```](https://github.com/espressif/arduino-esp32/blob/f9f70d2f73d16f7fb50f59e05323cd041acce830/libraries/Wire/src/Wire.h#L79)

GCC 8.4.0 (via [espressif/crosstool-NG esp-2021r1](https://github.com/espressif/crosstool-NG/releases/tag/esp-2021r1)) can't disambiguate the call as used in https://github.com/HelTecAutomation/Heltec_ESP32/blob/41756c5f887763dd6286efbdfcff20f3ea95b40a/src/BMP180.cpp#L12 and here the library wrongly initializes the bus in slave mode: https://github.com/HelTecAutomation/Heltec_ESP32/blob/41756c5f887763dd6286efbdfcff20f3ea95b40a/src/oled/SSD1306Wire.h#L63