### PR TITLE
Allow code to be used as an ESP-IDF component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+set(srcs
+    src/BMP180.cpp
+    src/oled/OLEDDisplay.cpp
+    src/oled/OLEDDisplayUi.cpp
+    src/heltec.cpp
+    src/lora/LoRa.cpp
+  )
+
+set(includedirs
+    src
+    src/lora
+    src/oled
+  )
+
+set(priv_includes )
+set(requires arduino)
+set(priv_requires )
+
+idf_component_register(INCLUDE_DIRS ${includedirs} PRIV_INCLUDE_DIRS ${priv_includes} SRCS ${srcs} REQUIRES ${requires} PRIV_REQUIRES ${priv_requires})
+
+function(maybe_add_component component_name)
+    idf_build_get_property(components BUILD_COMPONENTS)
+    if (${component_name} IN_LIST components)
+        idf_component_get_property(lib_name ${component_name} COMPONENT_LIB)
+        target_link_libraries(${COMPONENT_LIB} PUBLIC ${lib_name})
+    endif()
+endfunction()
+
+maybe_add_component(arduino)
+
+target_compile_options(${COMPONENT_TARGET} PUBLIC
+    -DESP32)

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -1,0 +1,3 @@
+menu "Heltec ESP32 Dev-Boards"
+
+endmenu

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,13 @@
+description: "A library for Heltec ESP32 (or ESP32+LoRa) based board"
+url: "https://github.com/HelTecAutomation/Heltec_ESP32.git"
+targets:
+  - esp32
+tags:
+  - arduino
+files:
+  include:
+    - "src/**/*"
+    - "CMakeLists.txt"
+    - "Kconfig.projbuild"
+  exclude:
+    - "**/*"


### PR DESCRIPTION
Add configuration files so we can use this code as an ESP-IDF component.
Just check out the repository into a project's components/Heltec_ESP32
folder.

This feature depends on Espressif's arduino-esp32 project, which is
available for ESP-IDF 4.4.

Also add an empty Kconfig menu for future customization.