### PR TITLE
Support heltec V3 board capabilities

### DIFF
--- a/src/heltec.cpp
+++ b/src/heltec.cpp
@@ -6,23 +6,22 @@
 
 Heltec_ESP32::Heltec_ESP32(){
 
-#if defined( WIFI_Kit_32 ) || defined( WIFI_LoRa_32 ) || defined( WIFI_LoRa_32_V2 )
-      display = new SSD1306Wire(0x3c, SDA_OLED, SCL_OLED, RST_OLED, GEOMETRY_128_64);
+#if defined( Class_Wifi_Kit ) || defined( Class_Wifi_LoRa )
+	display = new SSD1306Wire(0x3c, SDA_OLED, SCL_OLED, RST_OLED, GEOMETRY_128_64);
 #elif defined( Wireless_Stick )
-	  display = new SSD1306Wire(0x3c, SDA_OLED, SCL_OLED, RST_OLED, GEOMETRY_64_32);
+	display = new SSD1306Wire(0x3c, SDA_OLED, SCL_OLED, RST_OLED, GEOMETRY_64_32);
 #endif
 }
 
 Heltec_ESP32::~Heltec_ESP32(){
-#if defined( WIFI_Kit_32 ) || defined( WIFI_LoRa_32 ) || defined( WIFI_LoRa_32_V2 ) || defined( Wireless_Stick )
+#ifdef Heltec_Screen
 	delete display;
 #endif
 }
 
 void Heltec_ESP32::begin(bool DisplayEnable, bool LoRaEnable, bool SerialEnable, bool PABOOST, long BAND) {
 
-#if defined( WIFI_LoRa_32_V2 ) || defined( Wireless_Stick ) || defined( Wireless_Stick_Lite ) || defined(WIFI_Kit_32) || defined( Wireless_Bridge )
-
+#ifdef Heltec_Vext
 	VextON();
 #endif
 
@@ -37,14 +36,14 @@ void Heltec_ESP32::begin(bool DisplayEnable, bool LoRaEnable, bool SerialEnable,
 	// OLED
 	if (DisplayEnable)
 	{
-#if defined( Wireless_Stick_Lite ) || defined( Wireless_Bridge )
+#ifndef Heltec_Screen
 		if(SerialEnable)
 		{
-			Serial.print("Wireless Stick Lite and Wireless Bridge don't have an on board display, Display option must be FALSE!!!\r\n");
+			Serial.print("Board does not have an on board display, Display option must be FALSE!!!\r\n");
 		}
 #endif
 
-#if defined( WIFI_Kit_32 ) || defined( WIFI_LoRa_32 ) || defined( WIFI_LoRa_32_V2 ) || defined( Wireless_Stick )
+#ifdef Heltec_Screen
 		display->init();
 		//display->flipScreenVertically();
 		display->setFont(ArialMT_Plain_10);
@@ -60,14 +59,14 @@ void Heltec_ESP32::begin(bool DisplayEnable, bool LoRaEnable, bool SerialEnable,
 	// LoRa INIT
 	if (LoRaEnable)
 	{
-#if defined(WIFI_Kit_32)
-		if(SerialEnable && WIFI_Kit_32){
-			Serial.print("The WiFi Kit 32 not have LoRa function, LoRa option must be FALSE!!!\r\n");
+#ifndef Heltec_LoRa
+		if (SerialEnable) {
+			Serial.print("Board does not have LoRa function, LoRa option must be FALSE!!!\r\n");
 		}
 #endif
 
 
-#if defined( WIFI_LoRa_32 ) || defined( WIFI_LoRa_32_V2 ) || defined( Wireless_Stick ) || defined( Wireless_Stick_Lite ) || defined( Wireless_Bridge )
+#ifdef Heltec_LoRa
 		//LoRaClass LoRa;
 
 		SPI.begin(SCK,MISO,MOSI,SS);
@@ -77,7 +76,7 @@ void Heltec_ESP32::begin(bool DisplayEnable, bool LoRaEnable, bool SerialEnable,
 			if (SerialEnable){
 				Serial.print("Starting LoRa failed!\r\n");
 			}
-#if defined( WIFI_Kit_32 ) || defined( WIFI_LoRa_32 ) || defined( WIFI_LoRa_32_V2 ) || defined( Wireless_Stick )
+#ifdef Heltec_Screen
 			if(DisplayEnable){
 				display->clear();
 				display->drawString(0, 0, "Starting LoRa failed!");
@@ -90,7 +89,7 @@ void Heltec_ESP32::begin(bool DisplayEnable, bool LoRaEnable, bool SerialEnable,
 		if (SerialEnable){
 			Serial.print("LoRa Initial success!\r\n");
 		}
-#if defined( WIFI_Kit_32 ) || defined( WIFI_LoRa_32 ) || defined( WIFI_LoRa_32_V2 ) || defined( Wireless_Stick )
+#ifdef Heltec_Screen
 		if(DisplayEnable){
 			display->clear();
 			display->drawString(0, 0, "LoRa Initial success!");
@@ -104,6 +103,7 @@ void Heltec_ESP32::begin(bool DisplayEnable, bool LoRaEnable, bool SerialEnable,
 	pinMode(LED,OUTPUT);
 }
 
+#ifdef Heltec_Vext
 void Heltec_ESP32::VextON(void)
 {
 	pinMode(Vext,OUTPUT);
@@ -115,5 +115,6 @@ void Heltec_ESP32::VextOFF(void) //Vext default OFF
 	pinMode(Vext,OUTPUT);
 	digitalWrite(Vext, HIGH);
 }
+#endif
 
 Heltec_ESP32 Heltec;

--- a/src/heltec.h
+++ b/src/heltec.h
@@ -6,12 +6,46 @@
 #if defined(ESP32)
 
 #include <Arduino.h>
-#if defined( WIFI_Kit_32 ) || defined( WIFI_LoRa_32 ) || defined( WIFI_LoRa_32_V2 ) || defined( Wireless_Stick )
+
+/* Define board classes */
+#if defined( WIFI_Kit_32 ) || defined( WIFI_Kit_32_V3 )
+#define Class_Wifi_Kit
+#endif
+
+#if defined( WIFI_LoRa_32 ) || defined( WIFI_LoRa_32_V2 ) || defined( WIFI_LoRa_32_V3 )
+#define Class_Wifi_LoRa
+#endif
+
+#if defined( Wireless_Stick ) || defined( Wireless_Stick_Lite ) || defined( Wireless_Stick_V3 ) || defined( Wireless_Stick_Lite_V3 )
+#define Class_Wireless_Stick
+#endif
+
+
+/* Define board capabilities */
+#if defined( Class_Wifi_Kit ) || defined( Class_Wifi_LoRa ) || defined( Class_Wireless_Stick ) || defined( Wireless_Bridge )
+#define Heltec_Wifi
+#endif
+
+#if defined( Class_Wifi_LoRa ) || defined( Class_Wireless_Stick ) || defined( Wireless_Bridge )
+#define Heltec_LoRa
+#endif
+
+#if defined( Class_Wifi_Kit ) || defined( Class_Wifi_LoRa ) || defined( Wireless_Stick )
+#define Heltec_Screen
+#endif
+
+/* wifi kit 32 and WiFi LoRa 32(V1) do not have vext */
+#if defined( WIFI_Kit_32_V3 ) || defined( WIFI_LoRa_32_V2 ) || defined( WIFI_LoRa_32_V3 ) || defined( Class_Wireless_Stick ) || defined( Wireless_Bridge )
+#define Heltec_Vext
+#endif
+
+
+#ifdef Heltec_Screen
 #include <Wire.h>
 #include "oled/SSD1306Wire.h"
 #endif
 
-#if defined( WIFI_LoRa_32 ) || defined( WIFI_LoRa_32_V2 ) || defined( Wireless_Stick ) || defined( Wireless_Stick_Lite ) || defined( Wireless_Bridge )
+#ifdef Heltec_LoRa
 	#include <SPI.h>
 	#include "lora/LoRa.h"
 #endif
@@ -24,17 +58,19 @@ class Heltec_ESP32 {
 	~Heltec_ESP32();
 
     void begin(bool DisplayEnable=true, bool LoRaEnable=true, bool SerialEnable=true, bool PABOOST=true, long BAND=470E6);
-#if defined( WIFI_LoRa_32 ) || defined( WIFI_LoRa_32_V2 ) || defined( Wireless_Stick ) || defined( Wireless_Stick_Lite ) || defined( Wireless_Bridge )
+#ifdef Heltec_LoRa
     LoRaClass LoRa;
 #endif
 
-#if defined( WIFI_Kit_32 ) || defined( WIFI_LoRa_32 ) || defined( WIFI_LoRa_32_V2 ) || defined( Wireless_Stick )
+#ifdef Heltec_Screen
     SSD1306Wire *display;
 #endif
 
 /*wifi kit 32 and WiFi LoRa 32(V1) do not have vext*/
+#ifdef Heltec_Vext
     void VextON(void);
     void VextOFF(void);
+#endif
 };
 
 extern Heltec_ESP32 Heltec;

--- a/src/oled/OLEDDisplay.cpp
+++ b/src/oled/OLEDDisplay.cpp
@@ -79,9 +79,9 @@ bool OLEDDisplay::init() {
   }
   }
   #endif
-#if defined( WIFI_LoRa_32 ) || defined( WIFI_LoRa_32_V2 ) || defined( Wireless_Stick )
+  #ifdef Heltec_Screen
   resetDisplay(RST_OLED);
-#endif
+  #endif
 
   sendInitCommands();
 


### PR DESCRIPTION
This PR adds support for the latest V3 boards: `WIFI_Kit_32_V3` and `WIFI_LoRa_32_V3`

Without this, things like the screen, wifi, and lora do not work!
Because `heltec.cpp` checks for specific board macros.

Since Heltec now has a lot of boards in their inventory, I refactored `heltec.h` to map each board to certain capabilities: `Heltec_Wifi`, `Heltec_LoRa`, `Heltec_Screen`, `Heltec_Vext`

Then I changed the code in `heltec.cpp` to check for capabilities, not specific boards.
This will make it much easier to release new boards in the future.

Should fix #96 and #97

:heart: Heltec!