### PR TITLE
Update API.md - Wrong default Spreading Factor

### DIFF
--- a/src/lora/API.md
+++ b/src/lora/API.md
@@ -242,7 +242,7 @@ Change the spreading factor of the radio.
 ```arduino
 LoRa.setSpreadingFactor(spreadingFactor);
 ```
- * `spreadingFactor` - spreading factor, defaults to `7`
+ * `spreadingFactor` - spreading factor, defaults to `11`
 
 Supported values are between `6` and `12`. If a spreading factor of `6` is set, implicit header mode must be used to transmit and receive packets.
 


### PR DESCRIPTION
This tripped me up a little.

Change API docs to match default spreading factor used by Heltec.begin() which is SF 11.

See:
https://github.com/HelTecAutomation/Heltec_ESP32/blob/01a811fa8b6989fe2d0eccfea5c20fef72b7aaa4/src/lora/LoRa.cpp#L121

Related Closed Issue:
https://github.com/HelTecAutomation/Heltec_ESP32/issues/81