### PR TITLE
Fix the broken link that is supposed to redirect to the Heltec ESP32+…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ English | [简体中文](#简体中文)
 
 **This library requires installation of the [Heltec ESP32 development framework](https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series)! A detailed document about how to install the Heltec ESP32 development framework and this library available here:**
 
-[Heltec ESP32+LoRa Series Quick Start — esp32 latest documentation](https://docs.heltec.org/en/node/esp32/esp32_general_docs/quick_start.html)
+[Heltec ESP32+LoRa Series Quick Start — esp32 latest documentation](https://docs.heltec.org/en/node/esp32/quick_start.html)
 
 ## CONTENT
 
@@ -112,7 +112,7 @@ Please make sure use a high-quality Micro USB cable, it will reduce many problem
 
 **这个Arduino库必须配合[Heltec ESP32编译环境](https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series)一起使用！完整的“编译环境 + 库”的的教程可以参考这里：**
 
-[Heltec ESP32+LoRa Series Quick Start — esp32 latest documentation](https://docs.heltec.org/en/node/esp32/esp32_general_docs/quick_start.html)
+[Heltec ESP32+LoRa Series Quick Start — esp32 latest documentation](https://docs.heltec.org/en/node/esp32/quick_start.html)
 
 ***
 


### PR DESCRIPTION
As far as I understand, the link in the README.md file called "Heltec ESP32+LoRa Series Quick Start — esp32 latest documentation" is supposed to redirect to this page: https://docs.heltec.org/en/node/esp32/quick_start.html.

But it currently redirects to this non-existing page: https://docs.heltec.org/en/node/esp32/esp32_general_docs/quick_start.html.

In order do fix that, the old link was swapped to the functioning link.