### PR TITLE
Update radio.c

### DIFF
--- a/src/radio/radio.c
+++ b/src/radio/radio.c
@@ -8,6 +8,7 @@
 #include "../driver/sx126x-board.h"
 #include "../loramac/utilities.h"
 #include "../radio/radio.h"
+#include "Arduino.h"
 
 
 /*!


### PR DESCRIPTION
Need to include Arduino.h in radio.c file to correct a compile error indicating delay() is not implicitly defined